### PR TITLE
Potential fix for code scanning alert no. 27: Missing rate limiting

### DIFF
--- a/packages/brainsait-backend/src/routes/aiChampions.ts
+++ b/packages/brainsait-backend/src/routes/aiChampions.ts
@@ -1,5 +1,6 @@
 import { PrismaClient } from '@prisma/client';
 import express, { Request, Response } from 'express';
+import rateLimit from 'express-rate-limit';
 import { z } from 'zod';
 import { authenticate, AuthenticatedRequest } from '../middleware/auth';
 import { validateRequest } from '../middleware/validation';
@@ -7,6 +8,12 @@ import { validateRequest } from '../middleware/validation';
 const router = express.Router();
 const prisma = new PrismaClient();
 
+// Rate limiter for mentorship application (e.g., 5 requests/hour per IP)
+const mentorshipApplyLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000, // 1 hour
+  max: 5, // max 5 requests per windowMs
+  message: { error: 'Too many mentorship applications from this IP, please try again later.' }
+});
 // AI Champion Registration Schema
 const AIChampionRegistrationSchema = z.object({
   level: z.enum(['JUNIOR', 'SENIOR', 'LEAD']),
@@ -210,7 +217,7 @@ router.get('/available', async (req: Request, res: Response) => {
 });
 
 // Apply for mentorship
-router.post('/mentorship/apply', authenticate, validateRequest(MentorshipApplicationSchema), async (req: AuthenticatedRequest, res: Response) => {
+router.post('/mentorship/apply', mentorshipApplyLimiter, authenticate, validateRequest(MentorshipApplicationSchema), async (req: AuthenticatedRequest, res: Response) => {
   try {
     const applicationData = req.body;
     const userId = req.user?.id;


### PR DESCRIPTION
Potential fix for [https://github.com/Fadil369/Incubator/security/code-scanning/27](https://github.com/Fadil369/Incubator/security/code-scanning/27)

To fix the problem, we should add a rate-limiting middleware to restrict the number of times a user (or IP address) can hit sensitive endpoints in a given window. The most common and robust choice for Express.js is `express-rate-limit`. We’ll import it and configure a reasonable limit for the mentorship apply endpoint (e.g., 5 requests per hour per IP or user). This limit should be tuned based on business requirements.

**How to fix:**  
- Import the `express-rate-limit` library at the top of the file.
- Define a rate limiting middleware, e.g., allow 5 POSTs per hour per IP/user.
- Add this middleware to the `/mentorship/apply` route, immediately before `authenticate`.
- Only the code in the shown snippet will be changed.
- If the project doesn't already use this dependency, `express-rate-limit` must be added.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
