### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -1,5 +1,8 @@
 name: Deploy to Cloudflare
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, production]


### PR DESCRIPTION
Potential fix for [https://github.com/Fadil369/Incubator/security/code-scanning/1](https://github.com/Fadil369/Incubator/security/code-scanning/1)

To fix the issue, add a `permissions` block to restrict the GITHUB_TOKEN permissions for the entire workflow. The best approach is to add the `permissions` key at the root level of the workflow file, above or below the `on:` block but before the `jobs:` block. The minimal recommended permission is `contents: read`, which allows the workflow to read repository files but not to write or modify them. If certain jobs require more permissions (e.g., to comment on pull requests, update deployment statuses), those jobs can have per-job `permissions` blocks added later. For now, explicitly setting:
```yaml
permissions:
  contents: read
```
at the root of the workflow suffices for this fix.

Edits required:
- Add a root-level `permissions` block below the `name:` and above or below the `on:` section (conventional placement is after `name:`).
No new imports or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
