### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -1,4 +1,6 @@
 name: Deploy to Cloudflare
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Fadil369/Incubator/security/code-scanning/3](https://github.com/Fadil369/Incubator/security/code-scanning/3)

To remedy this, add a `permissions` block at the top level of the workflow (just below the `name:` or `on:`), so it applies to all jobs unless explicitly overridden. Most deployment workflows do not require write access to repository contents; they merely need to read code. The minimal setting is `permissions: contents: read`, which allows the workflow to clone the repository but prevents any accidental write actions (such as pushing code, opening PRs, editing issues, etc). If any deploy step needs more, you would specify it per-job. For this fix, you should add:

```yaml
permissions:
  contents: read
```

directly after the `name:` field (i.e., before `on:`). All other existing functionality is preserved.

No additional imports, methods, or definitions are needed; this is a purely declarative YAML change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
